### PR TITLE
Disable cloud monitoring

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -39,9 +39,10 @@ variable "node_groups" {
   type        = any # https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/variables.tf#L329
   default = {
     default = {
-      desired_capacity = 1
-      max_capacity     = 3
-      min_capacity     = 1
+      desired_capacity  = 1
+      max_capacity      = 3
+      min_capacity      = 1
+      enable_monitoring = false
 
       instance_types = ["m4.xlarge"]
       capacity_type  = "SPOT"

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -39,6 +39,9 @@ module "gke" {
   remove_default_node_pool          = true
   disable_legacy_metadata_endpoints = true
 
+  logging_service    = var.logging_enabled ? "logging.googleapis.com/kubernetes" : "none"
+  monitoring_service = var.monitoring_enabled ? "monitoring.googleapis.com/kubernetes" : "none"
+
   node_pools        = var.node_pools
   node_pools_labels = var.node_pools_labels
   node_pools_taints = var.node_pools_taints

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -79,3 +79,15 @@ variable "release_channel" {
   description = "Specifies release channel for kubernetes versions"
   default     = "STABLE"
 }
+
+variable "monitoring_enabled" {
+  type        = bool
+  description = "Enables GCP built in metrics collection (Disabled by default to prevent extra spents)"
+  default     = false
+}
+
+variable "logging_enabled" {
+  type        = bool
+  description = "Enables GCP built in logs collection (Disabled by default to prevent extra spents)"
+  default     = false
+}


### PR DESCRIPTION
For AWS:
- Disabled node_groups monitoring

For GCP:
- Disabled logs collecting
- Disabled metrics collecting

For Azure:
- Logging collection was already disabled

/close https://github.com/chainstack/graph-deployment/issues/24