### PR TITLE
Add instruction in helmfile README.md to direct users to setup kubectl

### DIFF
--- a/helmfile/README.md
+++ b/helmfile/README.md
@@ -9,6 +9,8 @@ You will need to install the following tools before proceeding
 2. [helmfile](https://github.com/roboll/helmfile)
 3. [helm-diff](https://github.com/databus23/helm-diff)
 
+Make sure to setup the kubectl config to point to the right kubernetes instance, see `terraform/<respective cloud provider>` for instructions.
+
 ## Network mode
 You can deploy graph node in network mode. In this case additional graph indexer components gets deployed, so that the node can join the graph network.
 
@@ -160,10 +162,10 @@ helmfile -f helmfile-network.yaml -n <namespace> apply
 Once the changed have been applied get the external ip for the the query service.
 ```
 $ kubectl get svc -n graph
-NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP       PORT(S)                                                       AGE
-graphprotocol-node-index       ClusterIP      some ip         <none>            8040/TCP,8020/TCP,8000/TCP,8001/TCP,8030/TCP                  64m
+NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP                               PORT(S)                                                       AGE
+graphprotocol-node-index       ClusterIP      some ip         <none>                                    8040/TCP,8020/TCP,8000/TCP,8001/TCP,8030/TCP                  64m
 graphprotocol-node-query       LoadBalancer   some ip         *Service external address (CNAME or IP)*  8040:31563/TCP,8020:32350/TCP,8000:30795/TCP,8001:31281/TCP   64m
-ipfs-ipfs                      ClusterIP      some ip         <none>            5001/TCP,8080/TCP                                             65m
-postgres-postgresql            ClusterIP      some ip         <none>            5432/TCP                                                      65m
-postgres-postgresql-headless   ClusterIP      None            <none>            5432/TCP                                                      65m
+ipfs-ipfs                      ClusterIP      some ip         <none>                                    5001/TCP,8080/TCP                                             65m
+postgres-postgresql            ClusterIP      some ip         <none>                                    5432/TCP                                                      65m
+postgres-postgresql-headless   ClusterIP      None            <none>                                    5432/TCP                                                      65m
 ```

--- a/helmfile/README.md
+++ b/helmfile/README.md
@@ -162,7 +162,7 @@ Once the changed have been applied get the external ip for the the query service
 $ kubectl get svc -n graph
 NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP       PORT(S)                                                       AGE
 graphprotocol-node-index       ClusterIP      some ip         <none>            8040/TCP,8020/TCP,8000/TCP,8001/TCP,8030/TCP                  64m
-graphprotocol-node-query       LoadBalancer   some ip         *CNAME you want*  8040:31563/TCP,8020:32350/TCP,8000:30795/TCP,8001:31281/TCP   64m
+graphprotocol-node-query       LoadBalancer   some ip         *Service external address (CNAME or IP)*  8040:31563/TCP,8020:32350/TCP,8000:30795/TCP,8001:31281/TCP   64m
 ipfs-ipfs                      ClusterIP      some ip         <none>            5001/TCP,8080/TCP                                             65m
 postgres-postgresql            ClusterIP      some ip         <none>            5432/TCP                                                      65m
 postgres-postgresql-headless   ClusterIP      None            <none>            5432/TCP                                                      65m

--- a/helmfile/README.md
+++ b/helmfile/README.md
@@ -134,3 +134,36 @@ Try to perform the test query:
 ```
 
 If everything is ok you will get a response containing indexed info.
+
+### Exposing Graph Protocol Node to the Internet
+The graph protocol node does not expose itself to the internet by default.
+One method of exposure is to utilize the LoadBalancer service. 
+Do note that the downside of this approach is that it would expose the installation to the web.
+
+In `values/graphprotocol-node-query.yaml` add the following line at the bottom
+```
+service:
+  type: LoadBalancer
+
+```
+
+This would expose ports used by the graph protocol node to the web. 
+Do note you'll need to run the below commands for changes to be reflected.
+```
+helmfile -f helmfile-standalone.yaml -n <namespace> apply
+
+or
+
+helmfile -f helmfile-network.yaml -n <namespace> apply
+```
+
+Once the changed have been applied get the external ip for the the query service.
+```
+$ kubectl get svc -n graph
+NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP       PORT(S)                                                       AGE
+graphprotocol-node-index       ClusterIP      some ip         <none>            8040/TCP,8020/TCP,8000/TCP,8001/TCP,8030/TCP                  64m
+graphprotocol-node-query       LoadBalancer   some ip         *CNAME you want*  8040:31563/TCP,8020:32350/TCP,8000:30795/TCP,8001:31281/TCP   64m
+ipfs-ipfs                      ClusterIP      some ip         <none>            5001/TCP,8080/TCP                                             65m
+postgres-postgresql            ClusterIP      some ip         <none>            5432/TCP                                                      65m
+postgres-postgresql-headless   ClusterIP      None            <none>            5432/TCP                                                      65m
+```


### PR DESCRIPTION
Add instruction in helmfile README.md to direct users to setup kubectl. Not everyone might start off reading the terraform folder. This minor edit provides a link to instructions on how to setup kubectl config.