### PR TITLE
Terraform AWS: Split node_groups by AZ to mitigate node autoscaling issues when EBS PV used

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -41,7 +41,7 @@ variable "node_groups" {
     default = {
       desired_capacity  = 1
       max_capacity      = 3
-      min_capacity      = 1
+      min_capacity      = 0
       enable_monitoring = false
 
       instance_types = ["m4.xlarge"]


### PR DESCRIPTION
/closes https://github.com/chainstack/graph-deployment/issues/56