### PR TITLE
Update ingress definitions for K8 versions 1.22 and up

### DIFF
--- a/charts/graphprotocol-indexer-service/templates/ingress.yaml
+++ b/charts/graphprotocol-indexer-service/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "graphprotocol-indexer-service.fullname" . }}
@@ -28,7 +28,9 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {{ include "graphprotocol-indexer-service.fullname" $ }}
-              servicePort: http
+              service:
+                name: {{ include "graphprotocol-indexer-service.fullname" $ }}
+                port:
+                  number: 80
     {{- end }}
 {{- end }}

--- a/charts/graphprotocol-node/templates/ingress.yaml
+++ b/charts/graphprotocol-node/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "graphprotocol-node.fullname" . }}
@@ -28,13 +28,15 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {{ include "graphprotocol-node.fullname" $ }}
-              servicePort: graphql
+              service:
+                name: {{ include "graphprotocol-node.fullname" $ }}
+                port:
+                  number: 443
     {{- end }}
 {{- end }}
 ---
 {{- if .Values.ingressWebsocket.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "graphprotocol-node.fullname" . }}-ws
@@ -63,7 +65,9 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {{ include "graphprotocol-node.fullname" $ }}
-              servicePort: graphql-ws
+              service:
+                name: {{ include "graphprotocol-node.fullname" $ }}
+                port:
+                  number: 443
     {{- end }}
 {{- end }}

--- a/charts/ipfs/templates/ingress-api.yaml
+++ b/charts/ipfs/templates/ingress-api.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingressApi.enabled -}}
 {{- $serviceName := include "ipfs.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
@@ -22,8 +22,10 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: 5001
+              service:
+                name: {{ $serviceName }}
+                port: 
+                  number: 5001
         {{- end -}}
         {{- if .Values.ingressApi.tls }}
   tls:

--- a/charts/ipfs/templates/ingress-gateway.yaml
+++ b/charts/ipfs/templates/ingress-gateway.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingressGateway.enabled -}}
 {{- $serviceName := include "ipfs.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
@@ -22,8 +22,10 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: 8080
+              service:
+                name: {{ $serviceName }}
+                port: 
+                  number: 8080
         {{- end -}}
         {{- if .Values.ingressGateway.tls }}
   tls:

--- a/helmfile/README.md
+++ b/helmfile/README.md
@@ -12,6 +12,7 @@ You will need to install the following tools before proceeding:
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/)
 1. [helmfile](https://github.com/roboll/helmfile)
 1. [helm-diff](https://github.com/databus23/helm-diff)
+1. Install postgres operator in your cluster: https://postgres-operator.readthedocs.io/en/latest/quickstart/
 
 Make sure to set up the kubectl config to point to the right Kubernetes instance. See `terraform/<respective cloud provider>` for instructions.
 


### PR DESCRIPTION
After K8 version 1.22 there has been [some changes to the ingress definitions](https://kubernetes.io/docs/reference/using-api/deprecation-guide/).
This PR updates the different ingress definitions to the new syntax.

It also adds a little reminder to the README file to install the postgres operator before running the helmfile or postgres will fail to deploy.

Thank you for sharing your graph-node deployments with the community 😃 