### PR TITLE
Add k8s 1.25 compatibility

### DIFF
--- a/charts/graphprotocol-indexer-service/templates/ingress.yaml
+++ b/charts/graphprotocol-indexer-service/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "graphprotocol-indexer-service.fullname" . }}
@@ -10,6 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+ingressClassName: nginx
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -28,7 +29,9 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {{ include "graphprotocol-indexer-service.fullname" $ }}
-              servicePort: http
+              service:
+                name: {{ include "graphprotocol-indexer-service.fullname" $ }}
+                port:
+                  name: http
     {{- end }}
 {{- end }}

--- a/charts/graphprotocol-node/templates/ingress.yaml
+++ b/charts/graphprotocol-node/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "graphprotocol-node.fullname" . }}
@@ -10,6 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: nginx
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -28,13 +29,15 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {{ include "graphprotocol-node.fullname" $ }}
-              servicePort: graphql
+              service:
+                name: {{ include "graphprotocol-node.fullname" $ }}
+                port:
+                  name: graphql
     {{- end }}
 {{- end }}
 ---
 {{- if .Values.ingressWebsocket.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "graphprotocol-node.fullname" . }}-ws
@@ -45,6 +48,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: nginx
   {{- if .Values.ingressWebsocket.tls }}
   tls:
     {{- range .Values.ingressWebsocket.tls }}
@@ -63,7 +67,9 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {{ include "graphprotocol-node.fullname" $ }}
-              servicePort: graphql-ws
+              service:
+                name: {{ include "graphprotocol-node.fullname" $ }}
+                port:
+                  name: graphql-ws
     {{- end }}
 {{- end }}

--- a/charts/graphprotocol-node/values.yaml
+++ b/charts/graphprotocol-node/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: graphprotocol/graph-node
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "v0.29.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/ipfs/templates/ingress-api.yaml
+++ b/charts/ipfs/templates/ingress-api.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingressApi.enabled -}}
 {{- $serviceName := include "ipfs.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
@@ -14,6 +14,7 @@ metadata:
           {{ $key }}: {{ $value | quote }}
         {{- end }}
 spec:
+  ingressClassName: nginx
   rules:
           {{- range .Values.ingressApi.hosts }}
           {{- $url := splitList "/" . }}
@@ -22,8 +23,10 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: 5001
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: 5001
         {{- end -}}
         {{- if .Values.ingressApi.tls }}
   tls:

--- a/charts/ipfs/templates/ingress-gateway.yaml
+++ b/charts/ipfs/templates/ingress-gateway.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingressGateway.enabled -}}
 {{- $serviceName := include "ipfs.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
@@ -14,6 +14,7 @@ metadata:
           {{ $key }}: {{ $value | quote }}
         {{- end }}
 spec:
+  ingressClassName: nginx
   rules:
           {{- range .Values.ingressGateway.hosts }}
           {{- $url := splitList "/" . }}
@@ -22,8 +23,10 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: 8080
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: 8080
         {{- end -}}
         {{- if .Values.ingressGateway.tls }}
   tls:

--- a/helmfile/helmfile-infra.yaml
+++ b/helmfile/helmfile-infra.yaml
@@ -21,12 +21,12 @@ environments:
 releases:
 - name: ingress-nginx
   chart: ingress-nginx/ingress-nginx
-  version: ~3.35.0
+  version: ~4.4.0
   installed: {{ .Values.ingressNginx.enabled }}
 
 - name: postgres-operator
   chart: postgres-operator/postgres-operator
-  version: ~1.7.0
+  version: ~1.9.0
   # Fixes CRD installation
   disableValidationOnInstall: true
   values:
@@ -36,7 +36,7 @@ releases:
 
 - name: cert-manager
   chart: jetstack/cert-manager
-  version: ~1.4.1
+  version: ~1.11.0
   values:
   - installCRDs: true
   installed: {{ .Values.certManager.enabled }}


### PR DESCRIPTION
- Refactor ingress with `networking.k8s.io/v1` instead of the deprecated "networking.k8s.io/v1beta1"
- Use newer versions of `ingress-nginx/ingress-nginx`, `postgres-operator/postgres-operator`, `jetstack/cert-manager` helm charts. 
